### PR TITLE
feat: 🎸 show inferred type (if SDK path was provided)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,23 +57,30 @@ will be searched recursively.
 $ swiftplantuml classdiagram --help
 OVERVIEW: Generate PlantUML script and view it and diagram in browser
 
-USAGE: swift-plant-uml classdiagram [--config <config>] [--exclude <exclude> ...] [--output <format>] [--verbose] [<paths> ...]
+USAGE: swift-plant-uml classdiagram [--config <config>] [--exclude <exclude> ...] [--output <format>] [--sdk <sdk>] [--verbose] [<paths> ...]
 
 ARGUMENTS:
-  <paths>                 List of paths to the files or directories containing swift sources
+  <paths>                 List of paths to the files or directories containing
+                          swift sources
 
 OPTIONS:
-  --config <config>       Path to custom configuration filed (otherwise will search for
-                          `.swiftplantuml.yml` in current directory)
-  --exclude <exclude>     paths to ignore source files. Takes precedence over arguments
-  --output <format>       Defines output format. Options: browser, browserImageOnly,
-                          consoleOnly
+  --config <config>       Path to custom configuration filed (otherwise will
+                          search for `.swiftplantuml.yml` in current directory)
+  --exclude <exclude>     paths to ignore source files. Takes precedence over
+                          arguments
+  --output <format>       Defines output format. Options: browser,
+                          browserImageOnly, consoleOnly
+  --sdk <sdk>             MacOSX SDK path used to handle type inference
+                          resolution, usually `$(xcrun --show-sdk-path -sdk
+                          macosx)`
   --verbose               Verbose
   --version               Show the version.
   -h, --help              Show help information.
 ```
 
 As `classdiagram` is the default subcommand you can omit it.
+
+Note: unknown type in diagrams for variables declared with type inference (e.g. `var count = 0`) *unless* you specify `sdk` argument
 
 ### Swift package
 
@@ -184,8 +191,6 @@ Click on `Edit in settings.json` and add the respective entry:
 - being able to merge extensions with their known type
 
 ## Known limitations
-- unknown type for variables declared with type inference (e.g. `var count = 0`)
-  - this is a limitation of SourceKitten :(
 - huge diagrams in browser
   - PlantUML limits image width and height to 4096 with the option to override this limit when using PlantUML.jar. locally so your option is to use the `--textonly`option and adjust/use it with PlantUML tools directly
 

--- a/Sources/SwiftPlantUMLFramework/ClassDiagramGenerator.swift
+++ b/Sources/SwiftPlantUMLFramework/ClassDiagramGenerator.swift
@@ -10,9 +10,11 @@ public struct ClassDiagramGenerator {
     /// generate diagram from Swift file(s)
     /// - Parameters:
     ///   - paths: representing paths to Swift source code files on the file system
+    ///   - configuration:  options to influence the generation and visual representation of the class diagram
     ///   - presenter: outputs the PlantUMLScript / Digram e.g. `PlantUMLBrowserPresenter` or `PlantUMLConsolePresenter`
-    public func generate(for paths: [String], with configuration: Configuration = .default, presentedBy presenter: PlantUMLPresenting = PlantUMLBrowserPresenter()) {
-        outputDiagram(for: generateScript(for: fileCollector.getFiles(for: paths), with: configuration), with: presenter)
+    ///   - sdkPath: MacOSX SDK path used to handle type inference resolution
+    public func generate(for paths: [String], with configuration: Configuration = .default, presentedBy presenter: PlantUMLPresenting = PlantUMLBrowserPresenter(), sdkPath: String? = nil) {
+        outputDiagram(for: generateScript(for: fileCollector.getFiles(for: paths), with: configuration, sdkPath: sdkPath), with: presenter)
     }
 
     /// generate diagram from a String containing Swift code
@@ -32,11 +34,11 @@ public struct ClassDiagramGenerator {
         return PlantUMLScript(items: allValidItems, configuration: configuration)
     }
 
-    func generateScript(for files: [URL], with configuration: Configuration = .default) -> PlantUMLScript {
+    func generateScript(for files: [URL], with configuration: Configuration = .default, sdkPath: String? = nil) -> PlantUMLScript {
         var allValidItems: [SyntaxStructure] = []
 
         for aFile in files {
-            if let validItems = SyntaxStructure.create(from: aFile)?.substructure {
+            if let validItems = SyntaxStructure.create(from: aFile, sdkPath: sdkPath)?.substructure {
                 allValidItems.append(contentsOf: validItems)
             }
         }

--- a/Sources/swiftplantuml/Commands/ClassDiagram.swift
+++ b/Sources/swiftplantuml/Commands/ClassDiagram.swift
@@ -23,6 +23,9 @@ extension SwiftPlantUML {
         ))
         var output: ClassDiagramOutput?
 
+        @Option(help: "MacOSX SDK path used to handle type inference resolution, usually `$(xcrun --show-sdk-path -sdk macosx)`")
+        var sdk: String?
+
         @Flag(help: "Verbose")
         var verbose: Bool = false
 
@@ -45,6 +48,8 @@ extension SwiftPlantUML {
                 config.files.exclude = exclude
             }
 
+            Logger.shared.info("SDK: \(sdk ?? "no SDK path provided")")
+
             let directory = FileManager.default.currentDirectoryPath // "/Users/d041771/git/__Private/SwiftPlantUML"
             let files = FileCollector().getFiles(for: allPaths, in: directory, honoring: config.files)
 
@@ -52,11 +57,11 @@ extension SwiftPlantUML {
 
             switch output {
             case .browserImageOnly:
-                generator.generate(for: files.map(\.path), with: config, presentedBy: PlantUMLBrowserPresenter(format: .imagePng))
+                generator.generate(for: files.map(\.path), with: config, presentedBy: PlantUMLBrowserPresenter(format: .imagePng),sdkPath: sdk)
             case .consoleOnly:
-                generator.generate(for: files.map(\.path), with: config, presentedBy: PlantUMLConsolePresenter())
+                generator.generate(for: files.map(\.path), with: config, presentedBy: PlantUMLConsolePresenter(),sdkPath: sdk)
             default:
-                generator.generate(for: files.map(\.path), with: config, presentedBy: PlantUMLBrowserPresenter(format: .default))
+                generator.generate(for: files.map(\.path), with: config, presentedBy: PlantUMLBrowserPresenter(format: .default), sdkPath: sdk)
             }
         }
     }

--- a/Tests/SwiftPlantUMLFrameworkTests/SyntaxStructureTests.swift
+++ b/Tests/SwiftPlantUMLFrameworkTests/SyntaxStructureTests.swift
@@ -96,6 +96,18 @@ final class SyntaxStructureTests: XCTestCase {
         XCTAssertFalse(plantUMLElement!.contains("<Title: View>"))
     }
 
+    func testStructureNoTypeInference() {
+        let cut = try! SyntaxStructure.create(from: getTestFile(), sdkPath: "IncorrectSdkPath")
+        let plantUMLElement = cut?.find(.class, named: "Bicycle")?.plantuml(context: PlantUMLContext())
+        XCTAssertFalse(plantUMLElement!.contains("~hasBasket : Bool"))
+    }
+
+    func testStructureTypeInference() {
+        let cut = try! SyntaxStructure.create(from: getTestFile(), sdkPath: "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk")
+        let plantUMLElement = cut?.find(.class, named: "Bicycle")?.plantuml(context: PlantUMLContext())
+        XCTAssertTrue(plantUMLElement!.contains("~hasBasket : Bool"))
+    }
+
     func getTestFile() throws -> URL {
         // https://stackoverflow.com/questions/47177036/use-resources-in-unit-tests-with-swift-package-manager
         let path = Bundle.module.path(forResource: "demo", ofType: "txt", inDirectory: "TestData") ?? "nonesense"


### PR DESCRIPTION
unknown type in class diagrams for variables with no explicit type
declaration (type-inference) *unless* you specify `sdk` argument

✅ Closes: #14