### PR TITLE
fix: 🐛 diagram in browser not shown

### DIFF
--- a/Sources/SwiftPlantUMLFramework/PlantUMLScript.swift
+++ b/Sources/SwiftPlantUMLFramework/PlantUMLScript.swift
@@ -57,7 +57,8 @@ public struct PlantUMLScript {
 
     func encodedText(completionHandler: @escaping (Result<String, NetworkError>) -> Void) {
         let escapedScript = text.stringByAddingPercentEncodingForFormData(plusForSpace: true) ?? ""
-        let parameters = "type=png&plantuml=\(escapedScript)"
+        // server expectation for parameters changed early 2022
+        let parameters = "\(escapedScript)"
         let postData = parameters.data(using: .utf8)
 
         var request = URLRequest(url: URL(string: "https://www.planttext.com/api/scripting")!, timeoutInterval: Double.infinity)


### PR DESCRIPTION
script in browser contained incorrectly `type=png&plantuml=`

Apparently the server changed its expectations how data are passed 