### PR TITLE
🐛 fix: When linking inheritedType, if the name includes `&`, separate and link it

### DIFF
--- a/Sources/SwiftPlantUMLFramework/Internal/SyntaxStructure+PlantUML.swift
+++ b/Sources/SwiftPlantUMLFramework/Internal/SyntaxStructure+PlantUML.swift
@@ -37,7 +37,16 @@ extension SyntaxStructure {
     private func addLinking(context: PlantUMLContext) {
         if inheritedTypes != nil, inheritedTypes!.count > 0 {
             inheritedTypes!.forEach { parent in
-                context.addLinking(item: self, parent: parent)
+                if parent.name?.contains("&") == true {
+                    parent.name?
+                        .components(separatedBy: "&")
+                        .forEach {
+                            let name = $0.trimmingCharacters(in: .whitespacesAndNewlines)
+                            context.addLinking(item: self, parent: SyntaxStructure(name: name))
+                        }
+                } else {
+                    context.addLinking(item: self, parent: parent)
+                }
             }
         }
     }

--- a/Tests/SwiftPlantUMLFrameworkTests/PlantUMLScriptTests.swift
+++ b/Tests/SwiftPlantUMLFrameworkTests/PlantUMLScriptTests.swift
@@ -118,6 +118,31 @@ final class PlantUMLScriptTests: XCTestCase {
         #endif
     }
 
+    func testMultipleInheritanceSeparatedByAmpersand() {
+        let code = """
+        class MyClass: ProtocolA & ProtocolB {}
+        """
+        let items = SyntaxStructure.create(from: code)!.substructure
+        let script = PlantUMLScript(items: items!)
+        let expected = """
+        @startuml
+        ' STYLE START
+        hide empty members
+        skinparam shadowing false
+        ' STYLE END
+        set namespaceSeparator none
+
+
+        class "MyClass" as MyClass << (C, DarkSeaGreen) >> {
+        }
+        ProtocolA <|-- MyClass : inherits
+        ProtocolB <|-- MyClass : inherits
+
+        @enduml
+        """
+        XCTAssertEqual(script.text.noSpacesAndNoLineBreaks, expected.noSpacesAndNoLineBreaks)
+    }
+
     func getTestFile(named: String = "basics") throws -> URL {
         // https://stackoverflow.com/questions/47177036/use-resources-in-unit-tests-with-swift-package-manager
         let path = Bundle.module.path(forResource: named, ofType: "txt", inDirectory: "TestData") ?? "nonesense"


### PR DESCRIPTION
resolves #80 

This PR implements the workaround for #80.
If the `name` in `inheritedTypes` received from `SourceKitten` contains an `&` delimiter, it separates them to link the inheritance relationships. 
If arbitrarily modifying the syntax structure parsed by `SourceKitten` does not align with the project's direction, feel free to close this PR.